### PR TITLE
Put variable into the component

### DIFF
--- a/components/Testimonials.php
+++ b/components/Testimonials.php
@@ -1,6 +1,5 @@
 <?php namespace Mja\Testimonials\Components;
 
-use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use Mja\Testimonials\Models\Testimonial;
 
@@ -18,7 +17,7 @@ class Testimonials extends ComponentBase
 
     public function onRun()
     {
-        $this->testimonials = Testimonial::whereIsPublic(1)->get();
+        $this->page['testimonials'] = $this->testimonials = Testimonial::whereIsPublic(1)->get();
     }
 
 }

--- a/components/Testimonials.php
+++ b/components/Testimonials.php
@@ -6,6 +6,7 @@ use Mja\Testimonials\Models\Testimonial;
 
 class Testimonials extends ComponentBase
 {
+    public $testimonials;
 
     public function componentDetails()
     {
@@ -17,7 +18,7 @@ class Testimonials extends ComponentBase
 
     public function onRun()
     {
-        $this->page['testimonials'] = Testimonial::whereIsPublic(1)->get();
+        $this->testimonials = Testimonial::whereIsPublic(1)->get();
     }
 
 }

--- a/components/testimonials/default.htm
+++ b/components/testimonials/default.htm
@@ -1,3 +1,5 @@
+{% set testimonials =  __SELF__.testimonials %}
+
 <div class="row">
     {% for testimonial in testimonials %}
         <div class="col-md-4">

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -12,3 +12,4 @@
     - Add author bio and avatar on testimonial
     - add_author_bio_column_on_testimonials_table.php
 1.1.3: Add Portugese translations. Thanks @eduardoborges
+1.1.4: Put query content into the component itself


### PR DESCRIPTION
I changed the variable store method. That way it is possible to override the component layout, as in my case, I wanted to use another layout. Putting the testimonial directly in the page woudn't allow me to do it.

Even better, that way you can have multiple instances of the component in the same page and they will each have their own scope.

So when overriding the template in a page, you have to do something like this:

```
[testimonials]

{% for testimonial in testimonials.testimonials %}
    custom html
{% endfor %}
```

Explanation of testimonials.testimonials

Left part references the component class Testimonials.php
The right part references the public field $testimonials in Testimonials.php